### PR TITLE
API improvements / ILI9341

### DIFF
--- a/display/ILI9341.c
+++ b/display/ILI9341.c
@@ -1,0 +1,646 @@
+/**
+ * @file ILI9341.c
+ * @author zaltora  (https://github.com/Zaltora)
+ * @copyright MIT License.
+ */
+//TODO: remove this
+#define USE_ILI9341 1
+/*********************
+ *      INCLUDES
+ *********************/
+#include "ILI9341.h"
+#if USE_ILI9341 != 0
+
+#include <stdbool.h>
+#include "lvgl/lv_core/lv_vdb.h"
+
+
+//TODO: remove this
+#define ILI9341_DEBUG 1
+
+/*********************
+ *      DEFINES
+ *********************/
+#ifndef ILI9341_SPI4_SUPPORT
+#define ILI9341_SPI4_SUPPORT 1
+#endif
+
+#ifndef ILI9341_SPI3_SUPPORT
+#define ILI9341_SPI3_SUPPORT 1
+#endif
+
+#ifndef ILI9341_MANUAL_DC
+#define ILI9341_MANUAL_DC 1
+#endif
+
+#ifndef ILI9341_MANUAL_CS
+#define ILI9341_MANUAL_CS 1
+#endif
+
+/* utility */
+#define BIT_MASK(a, b) (((unsigned) -1 >> (31 - (b))) & ~((1U << (a)) - 1))
+
+/* ILI9341 regular commands */
+#define ILI9341_NO_OPERATION            (0x00)
+#define ILI9341_SOFT_RESET              (0x01)
+#define ILI9341_DIS_INFOS               (0x04)
+#define ILI9341_DIS_STATUS              (0x09)
+#define ILI9341_DIS_POWER_MODE          (0x0A)
+#define ILI9341_DIS_MADCTL              (0x0B)
+#define ILI9341_DIS_PIXEL_FMT           (0x0C)
+#define ILI9341_DIS_IMAGE_FMT           (0x0D)
+#define ILI9341_DIS_SIGNAL_MODE         (0x0E)
+#define ILI9341_DIS_SELF_DIA_RESULT     (0x0F)
+#define ILI9341_SLEEP_ON                (0x10)
+#define ILI9341_SLEEP_OFF               (0x11)
+#define ILI9341_PARTIAL_MODE            (0x12)
+#define ILI9341_NORMAL_MODE             (0x13)
+#define ILI9341_INVERSION_OFF           (0x20)
+#define ILI9341_INVERSION_ON            (0x21)
+#define ILI9341_GAMMA_SET               (0x26)
+#define ILI9341_DIS_OFF                 (0x28)
+#define ILI9341_DIS_ON                  (0x29)
+#define ILI9341_COLUMN_ADDR_SET         (0x2A)
+#define ILI9341_PAGE_ADDR_SET           (0x2B)
+
+#define ILI9341_MEMORY_WRITE            (0x2C)
+#define ILI9341_COLOR_SET               (0x2D)
+#define ILI9341_MEMORY_READ             (0x2E)
+#define ILI9341_PARTIAL_AREA            (0x30)
+#define ILI9341_VERT_SCROLLING          (0x33)
+#define ILI9341_TEARING_LINE_OFF        (0x34)
+#define ILI9341_TEARING_LINE_ON         (0x35)
+#define ILI9341_MEMORY_ACCES_CTR        (0x36)
+#define ILI9341_VERT_SCROLL_START_ADDR  (0x37)
+#define ILI9341_IDLE_MODE_OFF           (0x38)
+#define ILI9341_IDLE_MODE_ON            (0x39)
+#define ILI9341_PIXEL_FMT_SET           (0x3A)
+#define ILI9341_WRITE_MEMORY_CONTINUE   (0x3C)
+#define ILI9341_READ_MEMORY_CONTINUE    (0x3E)
+#define ILI9341_SET_TEAR_SCANLINE       (0x44)
+#define ILI9341_GET_SCANLINE            (0x45)
+#define ILI9341_DIS_SET_BRIGHTNESS      (0x51)
+
+#define ILI9341_DIS_GET_BRIGHTNESS      (0x52)
+#define ILI9341_WRITE_CTRL_DIS          (0x53)
+#define ILI9341_READ_CTRL_DIS           (0x54)
+#define ILI9341_WRITE_ADAP_BRIGTH_CTR   (0x55)
+#define ILI9341_READ_ADAP_BRIGTH_CTR    (0x56)
+#define ILI9341_WRITE_CABC_MIN_BRIGTH   (0x5E)
+#define ILI9341_READ_CABC_MIN_BRIGTH    (0x5F)
+#define ILI9341_READ_ID1                (0xDA)
+#define ILI9341_READ_ID2                (0xDB)
+#define ILI9341_READ_ID3                (0xDC)
+
+/* ILI9341 Extended commands */
+
+#define ILI9341_RGB_INT_SIG_CTR         (0xB0)
+#define ILI9341_FRAME_CTR_NORMAL        (0xB1)
+#define ILI9341_FRAME_CTR_IDLE          (0xB2)
+#define ILI9341_FRAME_CTR_PARTIAL       (0xB3)
+#define ILI9341_DIS_INVERSION_CTR       (0xB4)
+#define ILI9341_BLANK_PORCH_CTR         (0xB5)
+#define ILI9341_DIS_FUNCTION_CTR        (0xB6)
+#define ILI9341_ENTRY_MODE_SET          (0xB7)
+#define ILI9341_BACKLIGTH_CTR_1         (0xB8)
+#define ILI9341_BACKLIGTH_CTR_2         (0xB9)
+#define ILI9341_BACKLIGTH_CTR_3         (0xBA)
+#define ILI9341_BACKLIGTH_CTR_4         (0xBB)
+#define ILI9341_BACKLIGTH_CTR_5         (0xBC)
+#define ILI9341_BACKLIGTH_CTR_7         (0xBE)
+#define ILI9341_BACKLIGTH_CTR_8         (0xBF)
+#define ILI9341_PWR_CTR_1               (0xC0)
+#define ILI9341_PWR_CTR_2               (0xC1)
+#define ILI9341_VCOM_CTR_1              (0xC5)
+#define ILI9341_VCOM_CTR_2              (0xC7)
+#define ILI9341_NV_MEMORY_WRITE         (0xD0)
+#define ILI9341_NV_MEMORY_PROTECT_KEY   (0xD1)
+#define ILI9341_NV_MEMORY_STATUS        (0xD2)
+#define ILI9341_READ_ID4                (0xD3)
+#define ILI9341_POS_GAMMA_COR           (0xE0)
+#define ILI9341_NEG_GAMMA_COR           (0xE1)
+#define ILI9341_DIG_GAMMA_CTR1          (0xE2)
+#define ILI9341_DIG_GAMMA_CTR2          (0xE3)
+#define ILI9341_UNKNOW                  (0xEF)
+#define ILI9341_INTERFACE_CTR           (0xF6)
+
+#define ILI9341_PWR_CTR_A               (0xCB)
+#define ILI9341_PWR_CTR_B               (0xCF)
+#define ILI9341_TIMING_CTR_A            (0xE8)
+#define ILI9341_UNKNOW_2                (0xE9)  //This cmd exist ?
+#define ILI9341_TIMING_CTR_B            (0xEA)
+#define ILI9341_PWR_ON_SEQ_CTR          (0xED)
+#define ILI9341_ENABLE_3G               (0xF2)
+#define ILI9341_PUMP_RATIO_CTR          (0xF7)
+
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static int _sendCommand(uint8_t cmd);
+static int _sendCommandData(uint8_t cmd, uint8_t* data, uint8_t len);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+
+/**********************
+ *      MACROS
+ **********************/
+#if ILI9341_DEBUG
+#include <stdio.h>
+#define debug(fmt, ...) printf("%s: " fmt "\n", "ILI9341", ## __VA_ARGS__)
+#else
+#define debug(fmt, ...)
+#endif
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void ili9341_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t * color_p)
+{
+    /*Return if the area is out the screen*/
+    if (x2 < 0 || y2 < 0 || x1 > LV_HOR_RES - 1 || y1 > LV_VER_RES - 1)
+    {
+        lv_flush_ready();
+        return;
+    }
+
+    /*Truncate the area to the screen*/
+    int32_t act_x1 = x1 < 0 ? 0 : x1;
+    int32_t act_y1 = y1 < 0 ? 0 : y1;
+    int32_t act_x2 = x2 > LV_HOR_RES - 1 ? LV_HOR_RES - 1 : x2;
+    int32_t act_y2 = y2 > LV_VER_RES - 1 ? LV_VER_RES - 1 : y2;
+
+
+    lv_flush_ready();
+}
+
+void ili9341_fill(int32_t x1, int32_t y1, int32_t x2, int32_t y2, lv_color_t color)
+{
+    /*The most simple case (but also the slowest) to put all pixels to the screen one-by-one*/
+
+    /*Return if the area is out the screen*/
+    if (x2 < 0 || y2 < 0 || x1 > LV_HOR_RES - 1 || y1 > LV_VER_RES - 1)
+    {
+        return;
+    }
+
+    /*Truncate the area to the screen*/
+    int32_t act_x1 = x1 < 0 ? 0 : x1;
+    int32_t act_y1 = y1 < 0 ? 0 : y1;
+    int32_t act_x2 = x2 > LV_HOR_RES - 1 ? LV_HOR_RES - 1 : x2;
+    int32_t act_y2 = y2 > LV_VER_RES - 1 ? LV_VER_RES - 1 : y2;
+
+}
+
+void ili9341_map(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t * color_p)
+{
+    /*Return if the area is out the screen*/
+    if (x2 < 0 || y2 < 0 || x1 > LV_HOR_RES - 1 || y1 > LV_VER_RES - 1)
+    {
+        return;
+    }
+
+    /*Truncate the area to the screen*/
+    int32_t act_x1 = x1 < 0 ? 0 : x1;
+    int32_t act_y1 = y1 < 0 ? 0 : y1;
+    int32_t act_x2 = x2 > LV_HOR_RES - 1 ? LV_HOR_RES - 1 : x2;
+    int32_t act_y2 = y2 > LV_VER_RES - 1 ? LV_VER_RES - 1 : y2;
+
+}
+
+/* Perform default init routine according */
+int ili9341_init(const ili9341_t *dev)
+{
+    int err;
+    switch (dev->height)
+    {
+    case 240:
+        break;
+    case 320:
+        break;
+    default:
+        debug("Unsupported screen height");
+        return -ENOTSUP;
+    }
+
+    switch (dev->protocol)
+    {
+#if (ILI9341_SPI4_SUPPORT)
+    case ILI9341_PROTO_SERIAL_8BIT:
+        break;
+#endif
+#if (ILI9341_SPI3_SUPPORT)
+    case ILI9341_PROTO_SERIAL_9BIT:
+        break;
+#endif
+    default:
+        debug("Unsupported protocol");
+        return -EPROTONOSUPPORT;
+    }
+
+
+    if((err = ili9341_unknow(dev)))
+        return err;
+
+    ili9341_pwr_ctrl_b_t pwr_ctrl_b_config = { 0 };
+    pwr_ctrl_b_config.dc_ena = 1 ;
+    pwr_ctrl_b_config.pceq = 1 ;
+
+    if((err = ili9341_power_control_b(dev, pwr_ctrl_b_config)))
+        return err;
+
+    ili9341_pwr_seq_ctrl_t pwr_seq_ctrl_config  = { 0 };
+    pwr_seq_ctrl_config.cp23_soft_start = 0 ;
+    pwr_seq_ctrl_config.cp1_soft_start = 2 ;
+    pwr_seq_ctrl_config.en_ddvdh = 3 ;
+    pwr_seq_ctrl_config.en_vgh = 1 ;
+    pwr_seq_ctrl_config.en_vgl = 2 ;
+    pwr_seq_ctrl_config.ddvdh_enh = 1;
+
+    if((err = ili9341_power_on_seq_ctrl(dev, pwr_seq_ctrl_config)))
+        return err;
+
+    ili9341_timing_ctrl_a_t timing_ctrl_a_config = { 0 };
+    timing_ctrl_a_config.now = 1 ;
+
+    if((err = ili9341_timing_ctrl_a(dev, timing_ctrl_a_config)))
+        return err;
+
+    ili9341_pwr_ctrl_a_t power_ctrl_a_config = { 0 };
+    power_ctrl_a_config.reg_vd = 4 ;
+    power_ctrl_a_config.vbc = 2 ;
+
+    if((err = ili9341_pwr_ctrl_a(dev, power_ctrl_a_config)))
+        return err;
+
+    ili9341_pump_ratio_ctrl_t pump_ration_ctrl_config = { 0 };
+    pump_ration_ctrl_config.ratio = 2 ;
+
+    if((err = ili9341_pump_ratio_ctrl(dev, pump_ration_ctrl_config)))
+        return err;
+
+    ili9341_timing_ctrl_b_t timing_ctrl_b_config = { 0 };
+    if((err = ili9341_timing_ctrl_b(dev, timing_ctrl_b_config)))
+        return err;
+
+    ili9341_pwr_ctrl_1_t pwr_ctrl_1_config = { 0 } ;
+    pwr_ctrl_1_config.vrh = 0b100011;
+    if((err = ili9341_pwr_ctrl_1(dev, pwr_ctrl_1_config)))
+        return err;
+
+    ili9341_pwr_ctrl_2_t pwr_ctrl_2_config = { 0 } ;
+    if((err = ili9341_pwr_ctrl_2(dev, pwr_ctrl_2_config)))
+        return err;
+
+    ili9341_vcom_ctrl_1_t vcom_ctrl_1_config = { 0 } ;
+    vcom_ctrl_1_config.vmh = 0b00111110;
+    vcom_ctrl_1_config.vml = 0b00101000;
+    if((err = ili9341_vcom_ctrl_1(dev, vcom_ctrl_1_config)))
+        return err;
+
+    ili9341_vcom_ctrl_2_t vcom_ctrl_2_config = { 0 } ;
+    vcom_ctrl_2_config.vmf = 6 ;
+    vcom_ctrl_2_config.nvm = 1 ;
+    if((err = ili9341_vcom_ctrl_2(dev, vcom_ctrl_2_config)))
+        return err;
+
+    ili9341_mem_ctrl_t ili9341_mem_ctrl_config = { 0 } ;
+    ili9341_mem_ctrl_config.mx = 1 ;
+    ili9341_mem_ctrl_config.bgr = 1 ;
+    if((err = ili9341_mem_ctrl(dev, ili9341_mem_ctrl_config)))
+        return err;
+
+    ili9341_vert_scroll_start_t ili9341_vert_scroll_start_config = { 0 };
+    if((err = ili9341_vert_scroll_start(dev, ili9341_vert_scroll_start_config)))
+        return err;
+
+    ili9341_px_fmt_t ili9341_pixel_fmt_config = { 0 };
+    ili9341_pixel_fmt_config.dbi = 0b101 ;
+    ili9341_pixel_fmt_config.dpi = 0b101 ;
+    if((err = ili9341_pixel_fmt(dev, ili9341_pixel_fmt_config)))
+        return err;
+
+    ili9341_frame_rate_ctrl_t ili9341_frame_rate_ctrl_config = { 0 };
+    ili9341_frame_rate_ctrl_config.rtna = 0b11000 ;
+    if((err = ili9341_frame_rate_ctrl(dev, ili9341_frame_rate_ctrl_config)))
+        return err;
+
+    ili9341_dis_fn_ctrl_t ili9341_dis_fn_ctrl_config = { 0 };
+    ili9341_dis_fn_ctrl_config.ptg = 0b10 ;
+    ili9341_dis_fn_ctrl_config.isc = 0b0010 ;
+    ili9341_dis_fn_ctrl_config.rev = 0b1 ;
+    ili9341_dis_fn_ctrl_config.nl = 0b100111;
+    if((err = ili9341_display_fn_ctrl(dev, ili9341_dis_fn_ctrl_config)))
+        return err;
+
+    ili9341_ena_3g_t ili9341_ena_3g_config = { 0 };
+    if((err = ili9341_enable_3g(dev, ili9341_ena_3g_config)))
+        return err;
+
+    ili9341_gamma_set_t ili9341_gamma_set_config = { 0 };
+    ili9341_gamma_set_config.gamma_set = 0x01 ;
+    if((err = ili9341_gamma_set(dev, ili9341_gamma_set_config)))
+        return err;
+
+
+    ili9341_gamma_cor_t ili9341_gamma_config = { 0 };
+    ili9341_gamma_config.v63 = 0x0F ;
+    ili9341_gamma_config.v62 = 0x31 ;
+    ili9341_gamma_config.v61 = 0x2B ;
+    ili9341_gamma_config.v59 = 0x0C ;
+    ili9341_gamma_config.v57 = 0x0E ;
+    ili9341_gamma_config.v50 = 0x08 ;
+    ili9341_gamma_config.v43 = 0x4E ;
+    ili9341_gamma_config.v36 = 0x0F ;
+    ili9341_gamma_config.v27 = 0x01 ;
+    ili9341_gamma_config.v20 = 0x37 ;
+    ili9341_gamma_config.v13 = 0x07 ;
+    ili9341_gamma_config.v6 = 0x10 ;
+    ili9341_gamma_config.v4 = 0x03 ;
+    ili9341_gamma_config.v2 = 0x0E ;
+    ili9341_gamma_config.v1 = 0x09 ;
+    ili9341_gamma_config.v0 = 0x00 ;
+    if((err = ili9341_gamma_cor(dev, ili9341_gamma_pos, ili9341_gamma_config)))
+        return err;
+
+    ili9341_gamma_config.v63 = 0x00 ;
+    ili9341_gamma_config.v62 = 0x0E ;
+    ili9341_gamma_config.v61 = 0x14 ;
+    ili9341_gamma_config.v59 = 0x03 ;
+    ili9341_gamma_config.v57 = 0x11 ;
+    ili9341_gamma_config.v50 = 0x07 ;
+    ili9341_gamma_config.v43 = 0x31 ;
+    ili9341_gamma_config.v36 = 0x0C ;
+    ili9341_gamma_config.v27 = 0x01 ;
+    ili9341_gamma_config.v20 = 0x48 ;
+    ili9341_gamma_config.v13 = 0x08 ;
+    ili9341_gamma_config.v6 = 0x0F ;
+    ili9341_gamma_config.v4 = 0x0C ;
+    ili9341_gamma_config.v2 = 0x31 ;
+    ili9341_gamma_config.v1 = 0x36 ;
+    ili9341_gamma_config.v0 = 0x0F ;
+    if((err = ili9341_gamma_cor(dev, ili9341_gamma_neg, ili9341_gamma_config)))
+        return err;
+
+    //TODO: can we swap order for them ? to wait only 120 ms
+    ili9341_sleep_out(dev);
+    ili9341_displat_on(dev);
+
+    return 0;
+}
+
+
+int ili9341_unknow(const ili9341_t *dev)
+{
+    uint8_t data[3] = { 0x03, 0x80, 0x02  };
+    return _sendCommandData(ILI9341_UNKNOW, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_power_control_b(const ili9341_t *dev, ili9341_pwr_ctrl_b_t config)
+{
+    uint8_t data[3] = { 0 };
+    data[0] = 0x00 ;
+    data[1] = 0x81 | config.power_ctrl << 3 | config.drv_ena << 5 | config.pceq << 6 ;
+    data[2] = 0x20 | config.drv_vmh | (config.drv_vml & BIT_MASK(0,0)) << 3  |
+        (config.drv_vml & BIT_MASK(1,2)) << 5 | config.dc_ena << 4;
+    return _sendCommandData(ILI9341_PWR_CTR_B, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_power_on_seq_ctrl(const ili9341_t *dev, ili9341_pwr_seq_ctrl_t config)
+{
+    uint8_t data[4] = { 0 };
+    data[0] = 0x44 | config.cp23_soft_start | config.cp1_soft_start << 4;
+    data[1] = config.en_ddvdh | config.en_vcl << 4 ;
+    data[2] = config.en_vgl | config.en_vgh << 4 ;
+    data[3] = 0x01 | config.ddvdh_enh << 7 ;
+    return _sendCommandData(ILI9341_PWR_ON_SEQ_CTR, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_timing_ctrl_a(const ili9341_t *dev, ili9341_timing_ctrl_a_t config)
+{
+    uint8_t data[3] = { 0 };
+    data[0] = 0x84 | config.now ;
+    data[1] = config.cr | config.eq <<4 ;
+    data[2] = 0x78 | config.pc ;
+    return _sendCommandData(ILI9341_TIMING_CTR_A, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_pwr_ctrl_a(const ili9341_t *dev, ili9341_pwr_ctrl_a_t config)
+{
+    uint8_t data[5] = { 0 };
+    data[0] = 0x39 ;
+    data[1] = 0x2C ;
+    data[2] = 0x00 ;
+    data[3] = 0x30 | config.reg_vd ;
+    data[4] = config.vbc ;
+    return _sendCommandData(ILI9341_PWR_CTR_A, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_pump_ratio_ctrl(const ili9341_t *dev, ili9341_pump_ratio_ctrl_t config)
+{
+    if (config.ratio <= 1)
+    {
+       return -ENOTSUP; //Reserved area
+    }
+    uint8_t data[1] = { 0 };
+    data[0] = config.ratio << 4;
+    return _sendCommandData(ILI9341_PUMP_RATIO_CTR, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_timing_ctrl_b(const ili9341_t *dev, ili9341_timing_ctrl_b_t config)
+{
+    uint8_t data[2] = { 0 };
+    data[0] = *(uint8_t*)&config;
+    return _sendCommandData(ILI9341_TIMING_CTR_B, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_pwr_ctrl_1(const ili9341_t *dev, ili9341_pwr_ctrl_1_t config)
+{
+    uint8_t data[1] = { 0 };
+    data[0] = config.vrh ;
+    return _sendCommandData(ILI9341_PWR_CTR_1, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_pwr_ctrl_2(const ili9341_t *dev, ili9341_pwr_ctrl_2_t config)
+{
+    uint8_t data[1] = { 0 };
+    data[0] = 0x10 | config.bt ;
+    return _sendCommandData(ILI9341_PWR_CTR_2, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_vcom_ctrl_1(const ili9341_t *dev, ili9341_vcom_ctrl_1_t config)
+{
+    uint8_t data[2] = { 0 };
+    data[0] = config.vmh ;
+    data[1] = config.vml ;
+    return _sendCommandData(ILI9341_VCOM_CTR_1, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_vcom_ctrl_2(const ili9341_t *dev, ili9341_vcom_ctrl_2_t config)
+{
+    uint8_t data[1] = { 0 };
+    data[0] = *(uint8_t*)&config ;
+    return _sendCommandData(ILI9341_VCOM_CTR_2, data, sizeof(data));
+}
+
+int ili9341_mem_ctrl(const ili9341_t *dev, ili9341_mem_ctrl_t config)
+{
+    uint8_t data[1] = { 0 };
+    data[0] = *(uint8_t*)&config & BIT_MASK(2,7);
+    return _sendCommandData(ILI9341_MEMORY_ACCES_CTR, data, sizeof(data));
+}
+
+int ili9341_vert_scroll_start(const ili9341_t *dev, ili9341_vert_scroll_start_t config)
+{
+    uint8_t data[2] = { 0 };
+    data[0] = config.vsp >> 8 ;
+    data[1] = config.vsp & 0x0F ;
+    return _sendCommandData(ILI9341_VERT_SCROLL_START_ADDR, data, sizeof(data));
+}
+
+int ili9341_pixel_fmt(const ili9341_t *dev, ili9341_px_fmt_t config)
+{
+    if (config.dbi != 5 && config.dbi != 6)
+    {
+       return -ENOTSUP; //Reserved area
+    }
+    else if (config.dpi != 5 && config.dpi != 6)
+    {
+       return -ENOTSUP; //Reserved area
+    }
+    uint8_t data[1] = { 0 };
+    data[0] = config.dbi | config.dpi << 4 ;
+    return _sendCommandData(ILI9341_PIXEL_FMT_SET, data, sizeof(data));
+}
+
+int ili9341_frame_rate_ctrl(const ili9341_t *dev, ili9341_frame_rate_ctrl_t config)
+{
+    uint8_t data[2] = { 0 };
+    data[0] = config.diva ;
+    data[1] = config.rtna ;
+    return _sendCommandData(ILI9341_FRAME_CTR_NORMAL, data, sizeof(data));
+}
+
+int ili9341_display_fn_ctrl(const ili9341_t *dev, ili9341_dis_fn_ctrl_t config)
+{
+    uint8_t data[3] = { 0 };
+    data[0] = config.pt | config.ptg << 2 ;
+    data[1] = config.isc | config.sm << 4 | config.ss << 5 |
+        config.gs << 6 | config.rev << 7 ;
+    data[2] = config.nl ;
+    //data[3] = config.pcdiv ;  //FIXME: This data is needed ? datasheet said no ?
+    return _sendCommandData(ILI9341_DIS_FUNCTION_CTR, data, sizeof(data));
+}
+
+/**
+ *  @pre EXTC should be high to enable this CMD
+ */
+int ili9341_enable_3g(const ili9341_t *dev, ili9341_ena_3g_t config)
+{
+    uint8_t data[1] = { 0 };
+    data[0] = 0x02 | config.ena_3g ;
+    return _sendCommandData(ILI9341_ENABLE_3G, data, sizeof(data));
+}
+
+int ili9341_gamma_set(const ili9341_t *dev, ili9341_gamma_set_t config)
+{
+    uint8_t data[1] = { 0 };
+    data[0] = config.gamma_set ;
+    return _sendCommandData(ILI9341_GAMMA_SET, data, sizeof(data));
+}
+
+int ili9341_gamma_cor(const ili9341_t *dev, ili9341_gamma_type_e type, ili9341_gamma_cor_t config)
+{
+    uint8_t data[15] = { 0 };
+    data[0] = config.v63 ;
+    data[1] = config.v62 ;
+    data[2] = config.v61 ;
+    data[3] = config.v59 ;
+    data[4] = config.v57 ;
+    data[5] = config.v50 ;
+    data[6] = config.v43 ;
+    data[7] = config.v27 | config.v36 << 4 ;
+    data[8] = config.v20 ;
+    data[9] = config.v13 ;
+    data[10] = config.v6 ;
+    data[11] = config.v4 ;
+    data[12] = config.v2 ;
+    data[13] = config.v1 ;
+    data[14] = config.v0 ;
+
+    return _sendCommandData( type == ili9341_gamma_pos ?
+        ILI9341_POS_GAMMA_COR : ILI9341_NEG_GAMMA_COR,   data, sizeof(data));
+}
+
+int ili9341_sleep_out(const ili9341_t *dev)
+{
+    //TODO: Wait 120 ms ? (what is the best way to do it ?
+    return _sendCommand(ILI9341_SLEEP_OFF);
+}
+
+int ili9341_displat_on(const ili9341_t *dev)
+{
+    return _sendCommand(ILI9341_DIS_ON);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+static int _sendCommand(uint8_t cmd)
+{
+    debug("cmd: %02X",cmd);
+    return -EIO;
+}
+
+static int _sendCommandData(uint8_t cmd, uint8_t* data, uint8_t len)
+{
+#if ILI9341_DEBUG
+    printf("ILI9341: cmd: %02X data: ", cmd);
+    for (uint8_t i = 0 ; i < len ; i++)
+    {
+        printf("%02X ",data[i]);
+    }
+    printf("\n");
+#endif
+    return -EIO;
+}
+
+#endif

--- a/display/ILI9341.h
+++ b/display/ILI9341.h
@@ -1,0 +1,320 @@
+/**
+ * @file ILI9341.h
+ * @author zaltora  (https://github.com/Zaltora)
+ * @copyright MIT License.
+ * @warn ILI9341 Datasheet can be incomplete or got some errors. Take care !!
+ */
+
+#ifndef ILI9341_H
+#define ILI9341_H
+
+//TODO: remove this
+#define USE_ILI9341 1
+
+/*********************
+ *      INCLUDES
+ *********************/
+//#include "../../lv_drv_conf.h"
+#if USE_ILI9341 != 0
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include "lvgl/lv_misc/lv_color.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**
+ * I/O protocols
+ */
+typedef enum
+{
+    ILI9341_PROTO_8080_8BIT = 0, //!<  8080 8 bits
+    ILI9341_PROTO_8080_16BIT, //!<  8080 16 bits
+    ILI9341_PROTO_8080_9BIT, //!<  8080 9 bits
+    ILI9341_PROTO_8080_18BIT, //!<  8080 18 bits
+    ILI9341_PROTO_SERIAL_9BIT, //!<  SPI 9 bits
+    ILI9341_PROTO_SERIAL_8BIT, //!<  SPI 8 bits
+} ili9341_protocol_t;
+
+
+/**
+ * Device descriptor
+ */
+typedef struct
+{
+    ili9341_protocol_t protocol;
+    union
+    {
+#if (ILI9341_PAR_SUPPORT)
+        void* par_dev;
+#endif
+#if (ILI9341_SPI4_SUPPORT) || (ILI9341_SPI3_SUPPORT)
+        void* spi_dev;
+#endif
+    };
+
+#if (ILI9341_MANUAL_CS)
+		uint8_t cs_pin;
+#endif
+#if (ILI9341_SPI4_SUPPORT) && (ILI9341_MANUAL_DC)
+    uint8_t dc_pin;               //!< Data/Command GPIO pin, used by ILI9341_PROTO_SPI4
+#endif
+    uint16_t width;                //!< Screen width, 320 or 240
+    uint16_t height;               //!< Screen height, 240 or 320
+} ili9341_t;
+
+
+//register details
+typedef struct
+{
+    uint16_t power_ctrl : 2;
+    uint16_t drv_ena : 1;   //< For VCOM driving ability enhancement, DRV_ena = 1: Enable
+    uint16_t pceq : 1; //<  PC and EQ operation for power saving ( 0 disable ; 1 enable )
+    uint16_t drv_vmh : 3 ;
+    uint16_t drv_vml : 3 ;
+    uint16_t dc_ena  : 1 ; //< Discharge path enable. Enable high for ESD protection, 1: enable
+} ili9341_pwr_ctrl_b_t;
+
+typedef struct
+{
+    uint16_t cp23_soft_start : 2 ; //< soft start control
+    uint16_t cp1_soft_start : 2 ;
+    uint16_t en_ddvdh : 2 ; //< power on sequence control
+    uint16_t en_vcl : 2 ;
+    uint16_t en_vgl : 2 ;
+    uint16_t en_vgh : 2 ;
+    uint16_t ddvdh_enh : 1 ; //< DDVDH enhance mode(only for 8 external capacitors)
+} ili9341_pwr_seq_ctrl_t;
+
+typedef struct
+{
+    uint8_t now : 1 ; //< gate driver non-overlap timing control
+    uint8_t cr : 1 ; //< CR timing control
+    uint8_t eq : 1 ; //< EQ timing control
+    uint8_t pc : 2 ; //< pre-charge timing control
+} ili9341_timing_ctrl_a_t;
+
+typedef struct
+{
+    uint8_t reg_vd : 3 ; //< vcore control
+    uint8_t vbc : 3 ; //<  ddvdh control
+} ili9341_pwr_ctrl_a_t;
+
+typedef struct
+{
+    uint8_t ratio : 2 ; //< ratio control (00 / 01 reserved)
+} ili9341_pump_ratio_ctrl_t;
+
+typedef struct
+{
+    uint8_t vg_sw_t1 : 2 ;
+    uint8_t vg_sw_t2 : 2 ;
+    uint8_t vg_sw_t3 : 2 ;
+    uint8_t vg_sw_t4 : 2 ;
+} ili9341_timing_ctrl_b_t;
+
+typedef struct
+{
+    uint8_t vrh : 6 ;
+} ili9341_pwr_ctrl_1_t;
+
+typedef struct
+{
+    uint8_t bt : 3 ;
+} ili9341_pwr_ctrl_2_t;
+
+typedef struct
+{
+    uint8_t vmh : 7 ;
+    uint8_t :1 ;
+    uint8_t vml : 7 ;
+    uint8_t :1 ;
+} ili9341_vcom_ctrl_1_t;
+
+typedef struct
+{
+    uint8_t vmf : 7 ;
+    uint8_t nvm : 1 ;
+} ili9341_vcom_ctrl_2_t;
+
+typedef struct
+{
+    uint8_t : 2 ;
+    uint8_t mh : 1 ;
+    uint8_t bgr : 1 ;
+    uint8_t ml : 1 ;
+    uint8_t mv : 1 ;
+    uint8_t mx : 1 ;
+    uint8_t my : 1 ;
+} ili9341_mem_ctrl_t;
+
+typedef struct
+{
+    uint16_t vsp ;
+} ili9341_vert_scroll_start_t;
+
+typedef struct
+{
+    uint8_t dbi : 3 ;
+    uint8_t : 1 ;
+    uint8_t dpi : 3 ;
+    uint8_t : 1 ;
+} ili9341_px_fmt_t;
+
+typedef struct
+{
+    uint8_t diva : 2 ;
+    uint8_t rtna : 5 ;
+} ili9341_frame_rate_ctrl_t;
+
+typedef struct
+{
+    uint32_t pt : 2 ;
+    uint32_t ptg : 2 ;
+    uint32_t isc : 4 ;
+    uint32_t sm : 1 ;
+    uint32_t ss : 1 ;
+    uint32_t gs : 1 ;
+    uint32_t rev : 1 ;
+    uint32_t nl : 6 ;
+    uint32_t pcdiv : 6 ;
+} ili9341_dis_fn_ctrl_t;
+
+typedef struct
+{
+    uint8_t ena_3g : 1 ;
+} ili9341_ena_3g_t;
+
+typedef struct
+{
+    uint8_t gamma_set ;
+} ili9341_gamma_set_t;
+
+typedef struct
+{
+    uint8_t v63 : 4 ;
+    uint8_t : 4 ;
+    uint8_t v62 : 6 ;
+    uint8_t : 2 ;
+    uint8_t v61 : 6 ;
+    uint8_t : 2 ;
+    uint8_t v59 : 4 ;
+    uint8_t :4 ;
+    uint8_t v57 : 5 ;
+    uint8_t : 3 ;
+    uint8_t v50 : 4 ;
+    uint8_t : 4 ;
+    uint8_t v43 : 7 ;
+    uint8_t : 1;
+    uint8_t v36 : 4 ;
+    uint8_t v27 : 4 ;
+    uint8_t v20 : 7 ;
+    uint8_t : 1 ;
+    uint8_t v13 : 4 ;
+    uint8_t : 4;
+    uint8_t v6 : 5 ;
+    uint8_t : 3 ;
+    uint8_t v4 : 4 ;
+    uint8_t : 4 ;
+    uint8_t v2 : 6 ;
+    uint8_t : 2 ;
+    uint8_t v1 : 6 ;
+    uint8_t : 2 ;
+    uint8_t v0 : 4 ;
+    uint8_t : 4 ;
+
+} ili9341_gamma_cor_t;
+
+typedef enum {
+    ili9341_gamma_pos,
+    ili9341_gamma_neg,
+} ili9341_gamma_type_e;
+
+
+/**********************
+ *      MACROS
+ **********************/
+
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/* Flush the content of the internal buffer the specific area on the display
+ * This function is required only when LV_VDB_SIZE != 0 in lv_conf.h
+ * @param x1 First x point coordinate
+ * @param y1 First y point coordinate
+ * @param x2 Second x point coordinate
+ * @param y2 Second y point coordinate
+ * @param color_p Pointer to VDB buffer (color sized)
+ */
+void ili9341_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t * color_p);
+
+/* Write a color (called 'fill') to the a specific area on the display
+ * This function is required only when LV_VDB_SIZE == 0 in lv_conf.h
+ * @param x1 First x point coordinate
+ * @param y1 First y point coordinate
+ * @param x2 Second x point coordinate
+ * @param y2 Second y point coordinate
+ * @param color Color to fill
+ */
+void ili9341_fill(int32_t x1, int32_t y1, int32_t x2, int32_t y2, lv_color_t  color);
+
+/* Write a pixel array (called 'map') to the a specific area on the display
+ * This function is required only when LV_VDB_SIZE == 0 in lv_conf.h
+ * @param x1 First x point coordinate
+ * @param y1 First y point coordinate
+ * @param x2 Second x point coordinate
+ * @param y2 Second y point coordinate
+ * @param color_p Pointer to VDB buffer (color sized)
+ */
+void ili9341_map(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t * color_p);
+
+/**
+ * Default init for ILI9341
+ * @param dev Pointer to device descriptor
+ * @return Non-zero if error occured
+ */
+int ili9341_init(const ili9341_t *dev);
+
+
+
+
+//Command
+int ili9341_unknow(const ili9341_t *dev);
+int ili9341_power_control_b(const ili9341_t *dev, ili9341_pwr_ctrl_b_t config);
+int ili9341_power_on_seq_ctrl(const ili9341_t *dev, ili9341_pwr_seq_ctrl_t config);
+int ili9341_timing_ctrl_a(const ili9341_t *dev, ili9341_timing_ctrl_a_t config);
+int ili9341_pwr_ctrl_a(const ili9341_t *dev, ili9341_pwr_ctrl_a_t config);
+int ili9341_pump_ratio_ctrl(const ili9341_t *dev, ili9341_pump_ratio_ctrl_t config);
+int ili9341_timing_ctrl_b(const ili9341_t *dev, ili9341_timing_ctrl_b_t config);
+int ili9341_pwr_ctrl_1(const ili9341_t *dev, ili9341_pwr_ctrl_1_t config);
+int ili9341_pwr_ctrl_2(const ili9341_t *dev, ili9341_pwr_ctrl_2_t config);
+int ili9341_vcom_ctrl_1(const ili9341_t *dev, ili9341_vcom_ctrl_1_t config);
+int ili9341_vcom_ctrl_2(const ili9341_t *dev, ili9341_vcom_ctrl_2_t config);
+int ili9341_mem_ctrl(const ili9341_t *dev, ili9341_mem_ctrl_t config);
+int ili9341_vert_scroll_start(const ili9341_t *dev, ili9341_vert_scroll_start_t config);
+int ili9341_pixel_fmt(const ili9341_t *dev, ili9341_px_fmt_t config);
+int ili9341_frame_rate_ctrl(const ili9341_t *dev, ili9341_frame_rate_ctrl_t config);
+int ili9341_display_fn_ctrl(const ili9341_t *dev, ili9341_dis_fn_ctrl_t config);
+int ili9341_enable_3g(const ili9341_t *dev, ili9341_ena_3g_t config);
+int ili9341_gamma_set(const ili9341_t *dev, ili9341_gamma_set_t config);
+int ili9341_gamma_cor(const ili9341_t *dev, ili9341_gamma_type_e type, ili9341_gamma_cor_t config);
+
+//No parameters commands
+int ili9341_sleep_out(const ili9341_t *dev);
+int ili9341_displat_on(const ili9341_t *dev);
+
+///////////////////////////////////////////////////////////////////////////
+
+
+#endif
+
+#endif

--- a/display/SSD1306.c
+++ b/display/SSD1306.c
@@ -1,6 +1,10 @@
 /**
  * @file SSD1963.c
- * 
+ * @date   2016-2018
+ * @author zaltora  (https://github.com/Zaltora)
+ * @author urx (https://github.com/urx)
+ * @author Ruslan V. Uss (https://github.com/UncleRus)
+ * @copyright MIT License.
  */
 
 /*********************
@@ -8,8 +12,6 @@
  *********************/
 #include "SSD1306.h"
 #if USE_SSD1306 != 0
-
-#include <esp/spi.h>
 
 #include <stdbool.h>
 #include "lvgl/lv_core/lv_vdb.h"

--- a/display/SSD1306.h
+++ b/display/SSD1306.h
@@ -1,6 +1,10 @@
 /**
  * @file SSD1306.h
- * 
+ * @date   2016-2018
+ * @author zaltora  (https://github.com/Zaltora)
+ * @author urx (https://github.com/urx)
+ * @author Ruslan V. Uss (https://github.com/UncleRus)
+ * @copyright MIT License.
  */
 
 #ifndef SSD1306_H
@@ -65,10 +69,10 @@ typedef struct
     union
     {
 #if (SSD1306_I2C_SUPPORT)
-        void* i2c_dev;         	//!< I2C device descriptor, used by SSD1306_PROTO_I2C
+        lv_i2c_handle_t i2c_dev;         	//!< I2C device descriptor, used by SSD1306_PROTO_I2C
 #endif
 #if (SSD1306_SPI4_SUPPORT) || (SSD1306_SPI3_SUPPORT)
-        void* spi_dev;
+        lv_spi_handle_t spi_dev;
 #endif
     };
 #if (SSD1306_MANUAL_CS)

--- a/lv_drv_conf_templ.c
+++ b/lv_drv_conf_templ.c
@@ -41,12 +41,12 @@
  *  Delay API
  *-------------------*/
 #if LV_DRIVER_ENABLE_DELAY
-inline void lv_delay_us(uint32_t us)
+inline void lv_delay_us(const uint32_t us)
 {
     //Do the dependant port here
 }
 
-inline void lv_delay_ms(uint32_t ms)
+inline void lv_delay_ms(const uint32_t ms)
 {
     //Do the dependant port here
 }
@@ -55,12 +55,12 @@ inline void lv_delay_ms(uint32_t ms)
  *  Common API
  *-------------------*/
 #if LV_DRIVER_ENABLE_COMMON
-inline void lv_gpio_write(uint16_t pin, uint8_t val)
+inline void lv_gpio_write(lv_gpio_handle_t gpio, const uint8_t val)
 {
     //Do the dependant port here
 }
 
-inline uint8_t lv_gpio_read(uint16_t pin)
+inline uint8_t lv_gpio_read(lv_gpio_handle_t gpio)
 {
     //Do the dependant port here
 }
@@ -69,22 +69,22 @@ inline uint8_t lv_gpio_read(uint16_t pin)
  *  I2C API
  *-------------------*/
 #if LV_DRIVER_ENABLE_I2C
-inline int lv_i2c_write(void* i2c_dev, const uint8_t* reg, const void* data_out, uint16_t datalen)
+inline int lv_i2c_write(lv_i2c_handle_t i2c_dev, const uint8_t* reg, const void* data_out, uint16_t datalen)
 {
     //Do the dependant port here
 }
 
-inline int lv_i2c_read(void* i2c_dev, const uint8_t* reg, void* data_in, uint16_t datalen)
+inline int lv_i2c_read(lv_i2c_handle_t i2c_dev, const uint8_t* reg, void* data_in, uint16_t datalen)
 {
     //Do the dependant port here
 }
 
-inline int lv_i2c_write16(void* i2c_dev, const uint16_t* reg, const void* data_out, uint16_t datalen)
+inline int lv_i2c_write16(lv_i2c_handle_t i2c_dev, const uint16_t* reg, const void* data_out, uint16_t datalen)
 {
     //Do the dependant port here
 }
 
-inline int lv_i2c_read16(void* i2c_dev, const uint16_t* reg, void* data_in, uint16_t datalen)
+inline int lv_i2c_read16(lv_i2c_handle_t i2c_dev, const uint16_t* reg, void* data_in, uint16_t datalen)
 {
     //Do the dependant port here
 }
@@ -93,42 +93,42 @@ inline int lv_i2c_read16(void* i2c_dev, const uint16_t* reg, void* data_in, uint
  *  SPI API
  *-------------------*/
 #if LV_DRIVER_ENABLE_SPI
-inline int lv_spi_transaction(void* spi_dev, void* data_in, const void* data_out, uint16_t len, uint8_t word_size)
+inline int lv_spi_transaction(lv_spi_handle_t spi_dev, void* data_in, const void* data_out, uint16_t len, uint8_t word_size)
 {
     //Do the dependant port here
 }
 
-inline int lv_spi_repeat(void* spi_dev, const void* template, uint32_t repeats, uint8_t word_size)
+inline int lv_spi_repeat(lv_spi_handle_t spi_dev, const void* template, uint32_t repeats, uint8_t word_size)
 {
     //Do the dependant port here
 }
 
-inline int lv_spi_set_command(void* spi_dev, uint32_t value, uint8_t bits)
+inline int lv_spi_set_command(lv_spi_handle_t spi_dev, uint32_t value, uint8_t bits)
 {
     //Do the dependant port here
 }
 
-inline int lv_spi_set_address(void* spi_dev, uint32_t value, uint8_t bits)
+inline int lv_spi_set_address(lv_spi_handle_t spi_dev, uint32_t value, uint8_t bits)
 {
     //Do the dependant port here 
 }
 
-inline int lv_spi_set_dummy(void* spi_dev, uint8_t bits)
+inline int lv_spi_set_dummy(lv_spi_handle_t spi_dev, uint8_t bits)
 {
     //Do the dependant port here  
 }
 
-inline int lv_spi_clear_command(void* spi_dev)
+inline int lv_spi_clear_command(lv_spi_handle_t spi_dev)
 {
     //Do the dependant port here  
 }
 
-inline int lv_spi_clear_address(void* spi_dev)
+inline int lv_spi_clear_address(lv_spi_handle_t spi_dev)
 {
     //Do the dependant port here
 }
 
-inline int lv_spi_clear_dummy(void* spi_dev)
+inline int lv_spi_clear_dummy(lv_spi_handle_t spi_dev)
 {
     //Do the dependant port here 
 }
@@ -138,12 +138,12 @@ inline int lv_spi_clear_dummy(void* spi_dev)
  *  Parallel API
  *-------------------*/
 #if LV_DRIVER_ENABLE_PAR
-inline int lv_par_write(void* par_dev, const void* data_out, uint16_t len, uint8_t word_size)
+inline int lv_par_write(lv_par_handle_t par_dev, const void* data_out, uint16_t len, uint8_t word_size)
 {
     //Do the dependant port here
 }
 
-inline int lv_par_read(void* par_dev, void* data_in, uint16_t len, uint8_t word_size)
+inline int lv_par_read(lv_par_handle_t par_dev, void* data_in, uint16_t len, uint8_t word_size)
 {
     //Do the dependant port here
 }

--- a/lv_drv_conf_templ.h
+++ b/lv_drv_conf_templ.h
@@ -13,15 +13,29 @@
 /*********************
  *      INCLUDES
  *********************/
+/* Add specific sdk include here */
 
 /*********************
- *       OPTION
+ *       DEFINES
  *********************/
+/* Disable with 0 if driver don't use an specific api */
 #define LV_DRIVER_ENABLE_COMMON 1
 #define LV_DRIVER_ENABLE_DELAY 1
 #define LV_DRIVER_ENABLE_I2C 1
 #define LV_DRIVER_ENABLE_SPI 1
 #define LV_DRIVER_ENABLE_PAR 1
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+/* You can use a pointer handler or just a id number to reder to a device
+ * e.g: typedef const uint8_t lv_gpio_handle_t if you need just a bus id
+ * You can use device descriptor from your sdk too.
+ */
+typedef const void* lv_gpio_handle_t
+typedef const void* lv_i2c_handle_t
+typedef const void* lv_spi_handle_t
+typedef const void* lv_par_handle_t
 
 /*********************
  * 	HAL INTERFACE
@@ -43,13 +57,13 @@
  * Delay the given number of microseconds
  * @param us Time to wait in us
  */
-extern inline void lv_delay_us(uint32_t us);
+extern inline void lv_delay_us(const uint32_t us);
 
 /**
  * Delay the given number of milliseconds
  * @param ms Time to wait in ms
  */
-extern inline void lv_delay_ms(uint32_t ms);
+extern inline void lv_delay_ms(const uint32_t ms);
 
 #endif
 /*------------
@@ -62,14 +76,14 @@ extern inline void lv_delay_ms(uint32_t ms);
  * @param pin gpio Number
  * @param val Level to set
  */
-extern inline void lv_gpio_write(uint16_t pin, uint8_t val);
+extern inline void lv_gpio_write(lv_gpio_handle_t gpio, const uint8_t val);
 
 /**
  * Read current level gpio
  * @param pin gpio to read
  * @return gpio value
  */
-extern inline uint8_t lv_gpio_read(uint16_t pin);
+extern inline uint8_t lv_gpio_read(lv_gpio_handle_t gpio);
 
 #endif
 /*---------
@@ -85,7 +99,7 @@ extern inline uint8_t lv_gpio_read(uint16_t pin);
  * @param datalen Number of data byte to send
  * @return Non-Zero if error occured
  */
-extern inline int lv_i2c_write(void* i2c_dev, const uint8_t* reg, const void* data_out, uint16_t datalen);
+extern inline int lv_i2c_write(lv_i2c_handle_t i2c_dev, const uint8_t* reg, const void* data_out, uint16_t datalen);
 
 /**
  * Do a I2C read transmission on 8 bits register device.
@@ -95,7 +109,7 @@ extern inline int lv_i2c_write(void* i2c_dev, const uint8_t* reg, const void* da
  * @param datalen Number of data byte to send
  * @return Non-Zero if error occured
  */
-extern inline int lv_i2c_read(void* i2c_dev, const uint8_t* reg, void* data_in, uint16_t datalen);
+extern inline int lv_i2c_read(lv_i2c_handle_t i2c_dev, const uint8_t* reg, void* data_in, uint16_t datalen);
 
 /**
  * Do a I2C write transmissionon 16 bits register device
@@ -105,7 +119,7 @@ extern inline int lv_i2c_read(void* i2c_dev, const uint8_t* reg, void* data_in, 
  * @param datalen Number of data byte to send
  * @return Non-Zero if error occured
  */
-extern inline int lv_i2c_write16(void* i2c_dev, const uint16_t* reg, const void* data_out, uint16_t datalen);
+extern inline int lv_i2c_write16(lv_i2c_handle_t i2c_dev, const uint16_t* reg, const void* data_out, uint16_t datalen);
 
 /**
  * Do a I2C write transmissionon 16 bits register device.
@@ -115,7 +129,7 @@ extern inline int lv_i2c_write16(void* i2c_dev, const uint16_t* reg, const void*
  * @param datalen Number of data byte to send
  * @return Non-Zero if error occured
  */
-extern inline int lv_i2c_read16(void* i2c_dev, const uint16_t* reg, void* data_in, uint16_t datalen);
+extern inline int lv_i2c_read16(lv_i2c_handle_t i2c_dev, const uint16_t* reg, void* data_in, uint16_t datalen);
 
 #endif
 /*---------
@@ -132,7 +146,7 @@ extern inline int lv_i2c_read16(void* i2c_dev, const uint16_t* reg, void* data_i
  * @param word_size Size of the word in byte
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_transaction(void* spi_dev, void* data_in, const void* data_out, uint16_t len, uint8_t word_size);
+extern inline int lv_spi_transaction(lv_spi_handle_t spi_dev, void* data_in, const void* data_out, uint16_t len, uint8_t word_size);
 
 /**
  * Do a SPI repeat send.
@@ -142,7 +156,7 @@ extern inline int lv_spi_transaction(void* spi_dev, void* data_in, const void* d
  * @param template_size Size of the template in byte
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_repeat(void* spi_dev, const void* template, uint32_t repeats, uint8_t template_size);
+extern inline int lv_spi_repeat(lv_spi_handle_t spi_dev, const void* template, uint32_t repeats, uint8_t template_size);
 
 /**
  * Set command to send for spi transaction
@@ -151,7 +165,7 @@ extern inline int lv_spi_repeat(void* spi_dev, const void* template, uint32_t re
  * @param bits Bits number
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_set_command(void* spi_dev, uint32_t value, uint8_t bits);
+extern inline int lv_spi_set_command(lv_spi_handle_t spi_dev, uint32_t value, uint8_t bits);
 
 /**
  * Set address to send for spi transaction
@@ -160,7 +174,7 @@ extern inline int lv_spi_set_command(void* spi_dev, uint32_t value, uint8_t bits
  * @param bits Bits number
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_set_address(void* spi_dev, uint32_t value, uint8_t bits);
+extern inline int lv_spi_set_address(lv_spi_handle_t spi_dev, uint32_t value, uint8_t bits);
 
 /**
  * Set Dummy bits to send for spi transaction
@@ -168,28 +182,28 @@ extern inline int lv_spi_set_address(void* spi_dev, uint32_t value, uint8_t bits
  * @param bits Bits number
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_set_dummy(void* spi_dev, uint8_t bits);
+extern inline int lv_spi_set_dummy(lv_spi_handle_t spi_dev, uint8_t bits);
 
 /**
  * Clear spi bus command
  * @param spi_dev Pointer to spi device
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_clear_command(void* spi_dev);
+extern inline int lv_spi_clear_command(lv_spi_handle_t spi_dev);
 
 /**
  * Clear spi bus address
  * @param spi_dev Pointer to spi device
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_clear_address(void* spi_dev);
+extern inline int lv_spi_clear_address(lv_spi_handle_t spi_dev);
 
 /**
  * Clear spi bus dummy bits
  * @param spi_dev Pointer to spi device
  * @return Non-Zero if error occured
  */
-extern inline int lv_spi_clear_dummy(void* spi_dev);
+extern inline int lv_spi_clear_dummy(lv_spi_handle_t spi_dev);
 
 #endif
 /*------------------
@@ -204,7 +218,7 @@ extern inline int lv_spi_clear_dummy(void* spi_dev);
  * @param word_size Size of the word in byte
  * @return Non-Zero if error occured
  */
-extern inline int lv_par_write(void* par_dev, const void* data_out, uint16_t len, uint8_t word_size);
+extern inline int lv_par_write(lv_par_handle_t par_dev, const void* data_out, uint16_t len, uint8_t word_size);
 
 
 /**
@@ -215,7 +229,7 @@ extern inline int lv_par_write(void* par_dev, const void* data_out, uint16_t len
  * @param word_size Size of the word in byte
  * @return Non-Zero if error occured
  */
-extern inline int lv_par_read(void* par_dev, void* data_in, uint16_t len, uint8_t word_size);
+extern inline int lv_par_read(lv_par_handle_t par_dev, void* data_in, uint16_t len, uint8_t word_size);
 
 #endif
 /*********************


### PR DESCRIPTION
Hi,
Since out last discussion, i added the handle typedef. I will rework SPI after. We got a lot of possibility now with the interface API.

I begin to write the ILI9341 driver. We can found many driver on internet but driver is only for SPI, and a lot of command are not described, just hex datasend. ILI9341 datasheet got some errors too. I will details all command i write. The register config of ili9341 are pretty chaotic so i use bit field struct to set value. and i copy the structure in to an array predefined with fixed value (see datasheet). that means user can't change unknown bits. 

Main features planned for this lib:
-All commands integration (lvl 0 API)
-More protocol supported (8080, SPI3, ... )


No need to merge now. I open this thread to discuss about features and advancements.