### PR TITLE
fix ssd1306 + ILI9341 transmissions upgrade

### DIFF
--- a/display/ILI9341.h
+++ b/display/ILI9341.h
@@ -46,14 +46,14 @@ typedef enum
  */
 typedef struct
 {
-    ili9341_protocol_t protocol;
+    ili9341_protocol_t protocol;   //!< Protocol used
     union
     {
 #if (ILI9341_PAR_SUPPORT)
-        lv_par_handle_t par_dev;
+        lv_par_handle_t par_dev;   //!< Parallel device descriptor
 #endif
 #if (ILI9341_SPI4_SUPPORT) || (ILI9341_SPI3_SUPPORT)
-        lv_spi_handle_t spi_dev;
+        lv_spi_handle_t spi_dev;   //!< SPI device descriptor
 #endif
     };
     lv_gpio_handle_t rst_pin;      //!< Reset pin

--- a/display/SSD1306.c
+++ b/display/SSD1306.c
@@ -116,7 +116,7 @@ static uint8_t _flag_redraw; //FIXME: Used to optimize the screen update, need t
 #if SSD1306_TRANSMISSION_CHECK
 #define verify_send(fn) do { int err; if((err = fn)) return err; } while (0)
 #else
-#define verify_send(fn)
+#define verify_send(fn) (fn)
 #endif
 /**********************
  *   GLOBAL FUNCTIONS

--- a/display/SSD1306.h
+++ b/display/SSD1306.h
@@ -71,13 +71,13 @@ typedef struct
     union
     {
 #if (SSD1306_I2C_SUPPORT)
-        lv_i2c_handle_t i2c_dev;         	//!< I2C device descriptor, used by SSD1306_PROTO_I2C
+        lv_i2c_handle_t i2c_dev;  //!< I2C device descriptor, used by SSD1306_PROTO_I2C
 #endif
 #if (SSD1306_SPI4_SUPPORT) || (SSD1306_SPI3_SUPPORT)
-        lv_spi_handle_t spi_dev;
+        lv_spi_handle_t spi_dev;  //!< SPI device descriptor
 #endif
     };
-    lv_gpio_handle_t rst_pin;
+    lv_gpio_handle_t rst_pin;     //!< Reset pin
     uint8_t width;                //!< Screen width, currently supported 128px, 96px
     uint8_t height;               //!< Screen height, currently supported 16px, 32px, 64px
 } ssd1306_t;

--- a/lv_drv_conf_templ.h
+++ b/lv_drv_conf_templ.h
@@ -311,8 +311,11 @@ static inline int lv_par_read(lv_par_handle_t par_dev, void* data_in, uint16_t l
  *--------------*/
 #define USE_ILI9341        1
 #if USE_ILI9341
-#define ILI9341_SPI4_SUPPORT 1
-#define ILI9341_SPI3_SUPPORT 1
+#define ILI9341_DEBUG          (0)
+#define ILI9341_SPI4_SUPPORT   (1)
+#define ILI9341_SPI3_SUPPORT   (1)
+#define ILI9341_SPI_MAX_SAMPLE (64) //half sample size send throw SPI (pixel = 2 byte)
+#define ILI9341_SPI_BYTESWAP   (0)  //Set Endiannes here if SPI don't support it
 #endif
 
 /*----------------


### PR DESCRIPTION
Hey, i update ili9341 driver and do a small fix on ssd1306.
Ili9341 update mainly update transmission system. flush/map/fill are complete and two major changes are here:
- Endian : As you know, you need inverse byte order when you send pixel to the screen, but some SPI driver can do it without need additional treatment. So i added a option for user to swap byte order or not if the SPI support it. (esp8266 support it, esp32 too if i am right)
- While/for : I got some infinite loop bug when setting was wrong ? i guess  that size calculation in certain case is not round... whatever. Using for loop is more robust (still guess) .

I got a screen ILI9341 with a electronic card from 4Dsystem. Test done. Everything work well !! byte order, algorithm, different VDB size. Feedback welcomed. Got a visual bug with fill/map but i think it is lvgl option that is wrong.
Next stage will be for doing a driver for AR1021 touch controller to finish test on the electronic card. If you know this controller or you got a driver for it, tell me. thank.
