### PR TITLE
SSD1306: Avoid discarding the I2C command

### DIFF
--- a/display/SSD1306.c
+++ b/display/SSD1306.c
@@ -116,7 +116,7 @@ static uint8_t _flag_redraw; //FIXME: Used to optimize the screen update, need t
 #if SSD1306_TRANSMISSION_CHECK
 #define verify_send(fn) do { int err; if((err = fn)) return err; } while (0)
 #else
-#define verify_send(fn)
+#define verify_send(fn) (fn)
 #endif
 /**********************
  *   GLOBAL FUNCTIONS


### PR DESCRIPTION
if SSD1306_TRANSMISSION_CHECK was not enable the i2c command was discarded 