### PR TITLE
Properly redraw window when focused

### DIFF
--- a/display/monitor.c
+++ b/display/monitor.c
@@ -279,6 +279,21 @@ static int sdl_refr(void * param)
 #if USE_KEYBOARD
             keyboard_handler(&event);
 #endif
+            if ((&event)->type == SDL_WINDOWEVENT) {
+                switch ((&event)->window.event) {
+                    case SDL_WINDOWEVENT_TAKE_FOCUS:
+                    case SDL_WINDOWEVENT_EXPOSED:
+                        SDL_UpdateTexture(texture, NULL, tft_fb, MONITOR_HOR_RES * sizeof(uint32_t));
+                        SDL_RenderClear(renderer);
+                        SDL_RenderCopy(renderer, texture, NULL, NULL);
+                        SDL_RenderPresent(renderer);
+                        break;
+                    default:
+                        break;
+                }
+                        
+            }
+            }
 	    }
 
 		/*Sleep some time*/


### PR DESCRIPTION
With this added piece of code, the PC simulator window gets redrawn when it (re)gains focus or gets partially or totally uncovered by other windows. I tested it only on Linux, and it seems to work fine.