### PR TITLE
fbdev: adding support for monochrome framebuffer

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -88,6 +88,11 @@ void fbdev_init(void)
 
 }
 
+void fbdev_exit(void)
+{
+    close(fbfd);
+}
+
 /**
  * Flush a buffer to the marked area
  * @param x1 left coordinate

--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -114,6 +114,8 @@ void fbdev_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_
     int32_t act_y2 = y2 > (int32_t)vinfo.yres - 1 ? (int32_t)vinfo.yres - 1 : y2;
 
     long int location = 0;
+    long int byte_location = 0;
+    unsigned char bit_location = 0;
 
     /*32 or 24 bit per pixel*/
     if(vinfo.bits_per_pixel == 32 || vinfo.bits_per_pixel == 24) {
@@ -154,6 +156,24 @@ void fbdev_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_
             for(x = act_x1; x <= act_x2; x++) {
                 location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * vinfo.xres;
                 fbp8[location] = color_p->full;
+                color_p++;
+            }
+
+            color_p += x2 - act_x2;
+        }
+    }
+    /*1 bit per pixel*/
+    else if(vinfo.bits_per_pixel == 1) {
+        uint8_t * fbp8 = (uint8_t *)fbp;
+        int32_t x;
+        int32_t y;
+        for(y = act_y1; y <= act_y2; y++) {
+            for(x = act_x1; x <= act_x2; x++) {
+                location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * vinfo.xres;
+                byte_location = location / 8; /* find the byte we need to change */
+                bit_location = location % 8; /* inside the byte found, find the bit we need to change */
+                fbp8[byte_location] &= ~(((uint8_t)(1)) << bit_location);
+                fbp8[byte_location] |= ((uint8_t)(color_p->full)) << bit_location;
                 color_p++;
             }
 
@@ -197,6 +217,8 @@ void fbdev_fill(int32_t x1, int32_t y1, int32_t x2, int32_t y2, lv_color_t color
     int32_t y;
 
     long int location = 0;
+    long int byte_location = 0;
+    unsigned char bit_location = 0;
 
     /*32 or 24 bit per pixel*/
     if(vinfo.bits_per_pixel == 32 || vinfo.bits_per_pixel == 24) {
@@ -221,6 +243,21 @@ void fbdev_fill(int32_t x1, int32_t y1, int32_t x2, int32_t y2, lv_color_t color
             for(y = act_y1; y <= act_y2; y++) {
                 location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * vinfo.xres;
                 fbp8[location] = color.full;
+            }
+        }
+    }
+    /*1 bit per pixel*/
+    else if(vinfo.bits_per_pixel == 1) {
+        uint8_t * fbp8 = (uint8_t *)fbp;
+        int32_t x;
+        int32_t y;
+        for(y = act_y1; y <= act_y2; y++) {
+            for(x = act_x1; x <= act_x2; x++) {
+                location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * vinfo.xres;
+                byte_location = location / 8; /* find the byte we need to change */
+                bit_location = location % 8; /* inside the byte found, find the bit we need to change */
+                fbp8[byte_location] &= ~(((uint8_t)(1)) << bit_location);
+                fbp8[byte_location] |= ((uint8_t)(color.full)) << bit_location;
             }
         }
     } else {
@@ -258,6 +295,8 @@ void fbdev_map(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t 
     int32_t act_y2 = y2 > (int32_t)vinfo.yres - 1 ? (int32_t)vinfo.yres - 1 : y2;
 
     long int location = 0;
+    long int byte_location = 0;
+    unsigned char bit_location = 0;
 
     /*32 or 24 bit per pixel*/
     if(vinfo.bits_per_pixel == 32 || vinfo.bits_per_pixel == 24) {
@@ -298,6 +337,24 @@ void fbdev_map(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t 
             for(x = act_x1; x <= act_x2; x++) {
                 location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * vinfo.xres;
                 fbp8[location] = color_p->full;
+                color_p++;
+            }
+
+            color_p += x2 - act_x2;
+        }
+    }
+    /*1 bit per pixel*/
+    else if(vinfo.bits_per_pixel == 1) {
+        uint8_t * fbp8 = (uint8_t *)fbp;
+        int32_t x;
+        int32_t y;
+        for(y = act_y1; y <= act_y2; y++) {
+            for(x = act_x1; x <= act_x2; x++) {
+                location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * vinfo.xres;
+                byte_location = location / 8; /* find the byte we need to change */
+                bit_location = location % 8; /* inside the byte found, find the bit we need to change */
+                fbp8[byte_location] &= ~(((uint8_t)(1)) << bit_location);
+                fbp8[byte_location] |= ((uint8_t)(color_p->full)) << bit_location;
                 color_p++;
             }
 

--- a/display/fbdev.h
+++ b/display/fbdev.h
@@ -36,6 +36,7 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 void fbdev_init(void);
+void fbdev_exit(void);
 void fbdev_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t * color_p);
 void fbdev_fill(int32_t x1, int32_t y1, int32_t x2, int32_t y2, lv_color_t color);
 void fbdev_map(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t * color_p);


### PR DESCRIPTION
Currently, fbdev driver does not support monochrome framebuffers.
This pull request addresses this issue. I've tested on linux with ssd1307 frame buffer driver (https://github.com/torvalds/linux/blob/master/drivers/video/fbdev/ssd1307fb.c) and it worked perfectly.