### PR TITLE
rename encoder to mousewheel - part 2

### DIFF
--- a/indev/indev.mk
+++ b/indev/indev.mk
@@ -1,7 +1,7 @@
 CSRCS += FT5406EE8.c
 CSRCS += keyboard.c
 CSRCS += mouse.c
-CSRCS += encoder.c
+CSRCS += mousewheel.c
 CSRCS += evdev.c
 CSRCS += XPT2046.c
 

--- a/indev/mousewheel.h
+++ b/indev/mousewheel.h
@@ -1,5 +1,5 @@
 /**
- * @file encoder.h
+ * @file mousewheel.h
  *
  */
 


### PR DESCRIPTION
adding a couple of lines which were missing from the original commit "rename evdev to mousewheel "