### PR TITLE
libinput_read should return touch coordinates in pixel not in mm

### DIFF
--- a/indev/libinput.c
+++ b/indev/libinput.c
@@ -136,8 +136,8 @@ bool libinput_read(lv_indev_data_t * data)
       case LIBINPUT_EVENT_TOUCH_MOTION:
       case LIBINPUT_EVENT_TOUCH_DOWN:
         touch_event = libinput_event_get_touch_event(event);
-        most_recent_touch_point.x = libinput_event_touch_get_x_transformed(touch_event, LV_HOR_SIZE);
-        most_recent_touch_point.y = libinput_event_touch_get_y_transformed(touch_event, LV_VER_SIZE);
+        most_recent_touch_point.x = libinput_event_touch_get_x_transformed(touch_event, LV_HOR_RES);
+        most_recent_touch_point.y = libinput_event_touch_get_y_transformed(touch_event, LV_VER_RES);
         libinput_button = LV_INDEV_STATE_PR;
         break;
       case LIBINPUT_EVENT_TOUCH_UP:

--- a/lv_drv_conf_templ.h
+++ b/lv_drv_conf_templ.h
@@ -263,8 +263,6 @@
 
 #if USE_LIBINPUT
 #  define LIBINPUT_NAME   "/dev/input/event0"        /*You can use the "evtest" Linux tool to get the list of devices and test them*/
-#  define LV_HOR_SIZE     (120)                      /*Horizontal screen size in mm*/
-#  define LV_VER_SIZE     (78)                       /*Vertial screen size in mm*/
 #endif  /*USE_LIBINPUT*/
 
 /*-------------------------------------------------


### PR DESCRIPTION
At the moment `libinput_read` returns the touch coordinates in `mm`, not in pixel as littlevgl expects. The `libinput_event_touch_get_x_transformed` simply maps the touch coordinate to the given width parameter. Changing this parameter from max screen size in `mm` to max screen size in pixel fixes the problem.