### PR TITLE
fix scaling, when EVDEV_CALIBRATE is false and EVDEV_SCALE true

### DIFF
--- a/indev/evdev.c
+++ b/indev/evdev.c
@@ -189,10 +189,9 @@ bool evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 #if EVDEV_SCALE
     data->point.x = map(evdev_root_x, 0, EVDEV_SCALE_HOR_RES, 0, lv_disp_get_hor_res(drv->disp));
     data->point.y = map(evdev_root_y, 0, EVDEV_SCALE_VER_RES, 0, lv_disp_get_ver_res(drv->disp));
-#endif
-#if EVDEV_CALIBRATE
-	data->point.x = map(evdev_root_x, EVDEV_HOR_MIN, EVDEV_HOR_MAX, 0, lv_disp_get_hor_res(drv->disp));
-	data->point.y = map(evdev_root_y, EVDEV_VER_MIN, EVDEV_VER_MAX, 0, lv_disp_get_ver_res(drv->disp));
+#elif EVDEV_CALIBRATE
+    data->point.x = map(evdev_root_x, EVDEV_HOR_MIN, EVDEV_HOR_MAX, 0, lv_disp_get_hor_res(drv->disp));
+    data->point.y = map(evdev_root_y, EVDEV_VER_MIN, EVDEV_VER_MAX, 0, lv_disp_get_ver_res(drv->disp));
 #else
     data->point.x = evdev_root_x;
     data->point.y = evdev_root_y;


### PR DESCRIPTION
This closes #92. data->point.x = evdev_root_x was always overriding the scaled x-coordinate, because if EVDEV_SCALE is true, EVDEV_CALIBRATE would be false and thus the non-scaled values would still be used.