### PR TITLE
fbdev.c: fix BSD screensize error

### DIFF
--- a/display/fbdev.c
+++ b/display/fbdev.c
@@ -51,6 +51,7 @@ struct bsd_fb_var_info{
 
 struct bsd_fb_fix_info{
     long int line_length;
+    long int smem_len;
 };
 
 /**********************
@@ -111,6 +112,7 @@ void fbdev_init(void)
     vinfo.xoffset = 0;
     vinfo.yoffset = 0;
     finfo.line_length = line_length;
+    finfo.smem_len = finfo.line_length * vinfo.yres;
 #else /* USE_BSD_FBDEV */
 
     // Get fixed screen information


### PR DESCRIPTION
Commit ca3eed87bab2d3d341659d8512c850ef29a179c1 broke the BSD build. This patch is to adapt to that change.