### PR TITLE
Add support for touchscreen events to the mouse driver

### DIFF
--- a/indev/mouse.c
+++ b/indev/mouse.c
@@ -89,17 +89,17 @@ void mouse_handler(SDL_Event * event)
 
         case SDL_FINGERUP:
             left_button_down = false;
-            last_x = LV_HOR_RES_MAX * event->tfinger.x / MONITOR_ZOOM;
-            last_y = LV_VER_RES_MAX * event->tfinger.y / MONITOR_ZOOM;
+            last_x = LV_HOR_RES * event->tfinger.x / MONITOR_ZOOM;
+            last_y = LV_VER_RES * event->tfinger.y / MONITOR_ZOOM;
             break;
         case SDL_FINGERDOWN:
             left_button_down = true;
-            last_x = LV_HOR_RES_MAX * event->tfinger.x / MONITOR_ZOOM;
-            last_y = LV_VER_RES_MAX * event->tfinger.y / MONITOR_ZOOM;
+            last_x = LV_HOR_RES * event->tfinger.x / MONITOR_ZOOM;
+            last_y = LV_VER_RES * event->tfinger.y / MONITOR_ZOOM;
             break;
         case SDL_FINGERMOTION:
-            last_x = LV_HOR_RES_MAX * event->tfinger.x / MONITOR_ZOOM;
-            last_y = LV_VER_RES_MAX * event->tfinger.y / MONITOR_ZOOM;
+            last_x = LV_HOR_RES * event->tfinger.x / MONITOR_ZOOM;
+            last_y = LV_VER_RES * event->tfinger.y / MONITOR_ZOOM;
             break;
     }
 

--- a/indev/mouse.c
+++ b/indev/mouse.c
@@ -85,7 +85,21 @@ void mouse_handler(SDL_Event * event)
         case SDL_MOUSEMOTION:
             last_x = event->motion.x / MONITOR_ZOOM;
             last_y = event->motion.y / MONITOR_ZOOM;
+            break;
 
+        case SDL_FINGERUP:
+            left_button_down = false;
+            last_x = LV_HOR_RES_MAX * event->tfinger.x / MONITOR_ZOOM;
+            last_y = LV_VER_RES_MAX * event->tfinger.y / MONITOR_ZOOM;
+            break;
+        case SDL_FINGERDOWN:
+            left_button_down = true;
+            last_x = LV_HOR_RES_MAX * event->tfinger.x / MONITOR_ZOOM;
+            last_y = LV_VER_RES_MAX * event->tfinger.y / MONITOR_ZOOM;
+            break;
+        case SDL_FINGERMOTION:
+            last_x = LV_HOR_RES_MAX * event->tfinger.x / MONITOR_ZOOM;
+            last_y = LV_VER_RES_MAX * event->tfinger.y / MONITOR_ZOOM;
             break;
     }
 


### PR DESCRIPTION
This fixes issue #96 where the mouse driver doesn't respond to touchscreen event.